### PR TITLE
Updating packaging docs for runFullTrust capability and multiple applications

### DIFF
--- a/docs/packaging/msix-packaging-tool.md
+++ b/docs/packaging/msix-packaging-tool.md
@@ -61,6 +61,8 @@ on the size of the package.
 
     In the manifest, the following changes will need to be made.
 
+    **Note**: Isolated win32 applications are not compatible with other application types within the same package.
+
     * Add `xmlns:previewsecurity2="http://schemas.microsoft.com/appx/manifest/preview/windows10/security/2"`
     to the `<Package>` element
 
@@ -71,6 +73,9 @@ on the size of the package.
 
     * In `<Application>` replace any existing entrypoint/trustlevel/runtimebehavior with
     `uap10:TrustLevel="appContainer" previewsecurity2:RuntimeBehavior="appSilo"`
+
+    * In `<Capabilities>` it is safe to remove the `<rescap:Capability name="runFullTrust">` unless
+    one of the extensions, such as `comServer`, requires it.
 
     ![image](images/11-packaging-manifest.png)
 

--- a/docs/packaging/msix-packaging-tool.md
+++ b/docs/packaging/msix-packaging-tool.md
@@ -76,7 +76,7 @@ on the size of the package.
 
     * **Note**: By default MPT, will automatically add `<rescap:Capability name="runFullTrust">` to
     `<Capabilities>` due to the app being a packaged Win32. This should be removed unless unless
-    the app has other manifested extensions which can affect the global machine state, such as
+    the app has other manifested extensions which can affect the user global state, such as
     `comServer` or `FirewallRules`, since those require the `runFullTrust` capability.
 
     ![image](images/11-packaging-manifest.png)

--- a/docs/packaging/msix-packaging-tool.md
+++ b/docs/packaging/msix-packaging-tool.md
@@ -75,7 +75,8 @@ on the size of the package.
     `uap10:TrustLevel="appContainer" previewsecurity2:RuntimeBehavior="appSilo"`
 
     * **Note**: By default MPT, will automatically add `<rescap:Capability name="runFullTrust">` to
-    `<Capabilities>` due to the app being a packaged Win32. This should be removed unless unless
+    `<Capabilities>` due to the app being a packaged Win32. This should be removed unless
+
     the app has other manifested extensions which can affect the user global state, such as
     `comServer` or `FirewallRules`, since those require the `runFullTrust` capability.
 

--- a/docs/packaging/msix-packaging-tool.md
+++ b/docs/packaging/msix-packaging-tool.md
@@ -76,7 +76,6 @@ on the size of the package.
 
     * **Note**: By default MPT, will automatically add `<rescap:Capability name="runFullTrust">` to
     `<Capabilities>` due to the app being a packaged Win32. This should be removed unless
-
     the app has other manifested extensions which can affect the user global state, such as
     `comServer` or `FirewallRules`, since those require the `runFullTrust` capability.
 

--- a/docs/packaging/msix-packaging-tool.md
+++ b/docs/packaging/msix-packaging-tool.md
@@ -74,8 +74,10 @@ on the size of the package.
     * In `<Application>` replace any existing entrypoint/trustlevel/runtimebehavior with
     `uap10:TrustLevel="appContainer" previewsecurity2:RuntimeBehavior="appSilo"`
 
-    * In `<Capabilities>` it is safe to remove the `<rescap:Capability name="runFullTrust">` unless
-    one of the extensions, such as `comServer`, requires it.
+    * **Note**: By default MPT, will automatically add `<rescap:Capability name="runFullTrust">` to
+    `<Capabilities>` due to the app being a packaged Win32. This should be removed unless unless
+    the app has other manifested extensions which can affect the global machine state, such as
+    `comServer` or `FirewallRules`, since those require the `runFullTrust` capability.
 
     ![image](images/11-packaging-manifest.png)
 


### PR DESCRIPTION
Clarifying that AppSilos can't be mixed and matched with other app types, and clarified runFullTrust capability