### PR TITLE
Correction - Should be package editor for MSIX -> Isolated Win32

### DIFF
--- a/docs/packaging/msix-packaging-tool.md
+++ b/docs/packaging/msix-packaging-tool.md
@@ -50,7 +50,7 @@ on the size of the package.
 
 ## MSIX -> Isolated Win32
 
-1. Select the far right option "Application Pacakge" and browse to the .msix file and click the
+1. Select the far right option "Package editor" and browse to the .msix file and click the
 "Open package" button.
 
     ![image](images/01-packaging-main-menu.png)


### PR DESCRIPTION
The documentation was mentioning the wrong option to click for MSIX -> Isolated Win32. It should be Package editor instead of Application package. I have made the correction in this PR.