### PR TITLE
[Docs][Profiler] Adjust profiler docs to reflect new ACP

### DIFF
--- a/docs/profiler/reference/Get-ProfilingResults.md
+++ b/docs/profiler/reference/Get-ProfilingResults.md
@@ -9,7 +9,7 @@ Retrieves capability access information from input ETL files.
 
 ```
 Get-ProfilingResults [[-EtlFilePaths] <string[]>] [-ExeNames <string[]>] [-ManifestPath <string>]
-[-RecordsOutputPath <string>] [-SummaryOutputPath <string>] [-PackageNames <string[]>] [-Quiet] [-ShowFirstParty]
+[-RecordsOutputPath <string>] [-SummaryOutputPath <string>] [-PackageNames <string[]>] [-Quiet]
 [-ShowNoNameObjectFailures] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -120,22 +120,6 @@ Aliases: r, RecordsOutput, RecordsPath
 Required: False
 Position: Named
 Default value: <working directory>\AccessAttemptRecords.csv
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ShowFirstParty
-
-Indicates whether to include first-party capabilities in the output. These may only be declared by Microsoft-signed packages.
-
-```yaml
-Type: System.Management.Automation.SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/profiler/reference/Merge-ProfilingResults.md
+++ b/docs/profiler/reference/Merge-ProfilingResults.md
@@ -11,14 +11,14 @@ Merges multiple Get-ProfilingResults output files into a single output file.
 
 ```
 Merge-ProfilingResults [-XmlInput] <string[]> [-OutputPath <string>] [-PackageNames <string[]>] [-Quiet]
-[-ShowFirstParty] [-ShowNoNameObjectFailures] [-WhatIf] [-Confirm] [<CommonParameters>]
+[-ShowNoNameObjectFailures] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### CSV Set
 
 ```
 Merge-ProfilingResults [-CsvInput] <string[]> [-OutputPath <string>] [-PackageNames <string[]>] [-Quiet]
-[-ShowFirstParty] [-ShowNoNameObjectFailures] [-WhatIf] [-Confirm] [<CommonParameters>]
+[-ShowNoNameObjectFailures] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -105,22 +105,6 @@ Aliases: p, Packages
 Required: False
 Position: Named
 Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ShowFirstParty
-
-Indicates whether to include first-party capabilities in the output. These may only be declared by Microsoft-signed packages.
-
-```yaml
-Type: System.Management.Automation.SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
These changes remove the documentation related to Microsoft-only capabilities. These are no longer supported by the profiler. 
The PR should be completed only when the new version of the profiler is released.